### PR TITLE
Add user reactivation endpoint and lifecycle event

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -105,8 +105,9 @@ func setupRouter(sqlDB *sql.DB, matchService *services.MatchService) *gin.Engine
 	protected.POST("/core-preferences", controllers.SaveCorePreferences)
 	protected.GET("/core-preferences", controllers.GetCorePreferences)
 	protected.PUT("/core-preferences", controllers.UpdateCorePreferences)
-	protected.POST("/deactivate", controllers.DeactivateCurrentUser)
-	protected.DELETE("", controllers.DeleteCurrentUser)
+        protected.POST("/deactivate", controllers.DeactivateCurrentUser)
+        protected.POST("/reactivate", controllers.ReactivateCurrentUser)
+        protected.DELETE("", controllers.DeleteCurrentUser)
 
 	// Allow authenticated users to retrieve profile enumerations via /user/profile/enums
 	protected.GET("/profile/enums", controllers.GetProfileEnums)

--- a/controllers/user_lifecycle.go
+++ b/controllers/user_lifecycle.go
@@ -63,6 +63,54 @@ func DeactivateCurrentUser(ctx *gin.Context) {
 	utils.RespondSuccess(ctx, http.StatusAccepted, utils.MessageResponse{Message: "Account deactivation scheduled"})
 }
 
+// ReactivateCurrentUser godoc
+// @Summary      Reactivate the authenticated user
+// @Description  Marks the caller's account as active and schedules downstream restoration.
+// @Tags         User
+// @Produce      json
+// @Param        payload  body      lifecycleRequest  false  "Optional reactivation reason"
+// @Success      202      {object}  utils.MessageResponse
+// @Failure      400      {object}  utils.ErrorResponse
+// @Failure      401      {object}  utils.ErrorResponse
+// @Failure      404      {object}  utils.ErrorResponse
+// @Failure      500      {object}  utils.ErrorResponse
+// @Router       /user/reactivate [post]
+// @Security     BearerAuth
+func ReactivateCurrentUser(ctx *gin.Context) {
+	userService := ctx.MustGet("userService").(*services.UserService)
+	userIDVal, exists := ctx.Get("userID")
+	if !exists {
+		utils.RespondError(ctx, http.StatusUnauthorized, nil, "Reactivate missing user id", "Unauthorized")
+		return
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		utils.RespondError(ctx, http.StatusUnauthorized, nil, "Reactivate invalid user id", "Unauthorized")
+		return
+	}
+
+	var req lifecycleRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			req = lifecycleRequest{}
+		} else {
+			utils.RespondError(ctx, http.StatusBadRequest, err, "Reactivate bind error", "Invalid input")
+			return
+		}
+	}
+
+	if err := userService.ReactivateUser(ctx.Request.Context(), userID, req.Reason); err != nil {
+		if errors.Is(err, repositories.ErrUserNotFound) {
+			utils.RespondError(ctx, http.StatusNotFound, err, "Reactivate user not found", "user not found")
+			return
+		}
+		utils.RespondError(ctx, http.StatusInternalServerError, err, "Reactivate service error", "Could not reactivate user")
+		return
+	}
+
+	utils.RespondSuccess(ctx, http.StatusAccepted, utils.MessageResponse{Message: "Account reactivation scheduled"})
+}
+
 // DeleteCurrentUser godoc
 // @Summary      Permanently delete the authenticated user
 // @Description  Removes the caller's account and enqueues delete events for downstream services.

--- a/internals/db/migrations/011_add_reactivate_lifecycle_event.sql
+++ b/internals/db/migrations/011_add_reactivate_lifecycle_event.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE user_lifecycle_outbox
+    DROP CONSTRAINT IF EXISTS user_lifecycle_outbox_event_type_chk;
+
+ALTER TABLE user_lifecycle_outbox
+    ADD CONSTRAINT user_lifecycle_outbox_event_type_chk CHECK (event_type IN ('deactivated', 'deleted', 'reactivated'));
+
+COMMIT;

--- a/models/outbox.go
+++ b/models/outbox.go
@@ -31,6 +31,8 @@ type UserLifecycleEventType string
 const (
 	// UserLifecycleEventTypeDeactivated indicates that the account has been deactivated but not removed.
 	UserLifecycleEventTypeDeactivated UserLifecycleEventType = "deactivated"
+	// UserLifecycleEventTypeReactivated indicates that the account has been reactivated and should be restored downstream.
+	UserLifecycleEventTypeReactivated UserLifecycleEventType = "reactivated"
 	// UserLifecycleEventTypeDeleted indicates that the account and related data have been removed from the core service.
 	UserLifecycleEventTypeDeleted UserLifecycleEventType = "deleted"
 )

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -91,6 +91,26 @@ func DeactivateUserTx(tx *sql.Tx, userID int) error {
 	return nil
 }
 
+// ReactivateUserTx sets a user's account as active within the supplied transaction.
+func ReactivateUserTx(tx *sql.Tx, userID int) error {
+	res, err := tx.Exec(`
+        UPDATE users
+        SET is_active = true, deactivated_at = NULL
+        WHERE id = $1 AND is_active = false`, userID)
+	if err != nil {
+		log.Printf("ReactivateUserTx exec error for user %d: %v", userID, err)
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
 // DeleteUserTx hard deletes a user row from the database within the supplied transaction.
 func DeleteUserTx(tx *sql.Tx, userID int) error {
 	res, err := tx.Exec(`DELETE FROM users WHERE id = $1`, userID)


### PR DESCRIPTION
## Summary
- add a POST /user/reactivate route and controller to re-enable the signed-in account
- emit a RabbitMQ lifecycle outbox event when an account is reactivated and support the new event type
- extend the database constraint to allow "reactivated" lifecycle events

## Testing
- ⚠️ `go test ./...` *(hangs locally and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e104f0a9c4832e8c1fb691701e4644