### PR TITLE
Allow inactive users to authenticate for reactivation

### DIFF
--- a/middlewares/authenticate.go
+++ b/middlewares/authenticate.go
@@ -1,11 +1,13 @@
 package middlewares
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt"
 	"github.com/icpinto/dating-app/models"
+	"github.com/icpinto/dating-app/repositories"
 	"github.com/icpinto/dating-app/services"
 )
 
@@ -30,17 +32,37 @@ func Authenticate(c *gin.Context) {
 		return
 	}
 
+	// Make the user ID available to downstream handlers regardless of account status.
+	c.Set("userID", claims.UserID)
+
 	// Retrieve the username based on user ID and set both in the context
 	userService := c.MustGet("userService").(*services.UserService)
 	username, err := userService.GetUsernameByID(claims.UserID)
 	if err != nil {
+		if errors.Is(err, repositories.ErrUserNotFound) && allowsInactiveAccess(c) {
+			// Allow specific routes (such as reactivation) to proceed even when the
+			// account is currently inactive. These handlers rely on the user ID from
+			// the token and do not require an active username lookup.
+			c.Set("username", "")
+			c.Next()
+			return
+		}
+
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
 		c.Abort()
 		return
 	}
 
-	c.Set("userID", claims.UserID)
 	c.Set("username", username)
 
 	c.Next() // Proceed to the next middleware or route handler
+}
+
+func allowsInactiveAccess(c *gin.Context) bool {
+	switch c.FullPath() {
+	case "/user/reactivate":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary
- update the authentication middleware to allow inactive users to access the reactivation route
- set the user ID on the context before the username lookup so handlers can proceed when the lookup is skipped

## Testing
- go test ./... *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e1079d9d28832e88c29d8ebbdd794e