### PR TITLE
Add authenticated user status endpoint

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -105,9 +105,10 @@ func setupRouter(sqlDB *sql.DB, matchService *services.MatchService) *gin.Engine
 	protected.POST("/core-preferences", controllers.SaveCorePreferences)
 	protected.GET("/core-preferences", controllers.GetCorePreferences)
 	protected.PUT("/core-preferences", controllers.UpdateCorePreferences)
-        protected.POST("/deactivate", controllers.DeactivateCurrentUser)
-        protected.POST("/reactivate", controllers.ReactivateCurrentUser)
-        protected.DELETE("", controllers.DeleteCurrentUser)
+	protected.POST("/deactivate", controllers.DeactivateCurrentUser)
+	protected.POST("/reactivate", controllers.ReactivateCurrentUser)
+	protected.GET("/status", controllers.GetUserStatus)
+	protected.DELETE("", controllers.DeleteCurrentUser)
 
 	// Allow authenticated users to retrieve profile enumerations via /user/profile/enums
 	protected.GET("/profile/enums", controllers.GetProfileEnums)

--- a/controllers/user_status.go
+++ b/controllers/user_status.go
@@ -1,0 +1,54 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/icpinto/dating-app/repositories"
+	"github.com/icpinto/dating-app/services"
+	"github.com/icpinto/dating-app/utils"
+)
+
+// GetUserStatus godoc
+// @Summary      Retrieve the authenticated user's activation status
+// @Description  Returns whether the caller's account is currently activated or deactivated.
+// @Tags         User
+// @Produce      json
+// @Success      200  {object}  utils.UserStatusResponse
+// @Failure      401  {object}  utils.ErrorResponse
+// @Failure      404  {object}  utils.ErrorResponse
+// @Failure      500  {object}  utils.ErrorResponse
+// @Router       /user/status [get]
+// @Security     BearerAuth
+func GetUserStatus(ctx *gin.Context) {
+	userService := ctx.MustGet("userService").(*services.UserService)
+
+	userIDVal, exists := ctx.Get("userID")
+	if !exists {
+		utils.RespondError(ctx, http.StatusUnauthorized, nil, "GetUserStatus missing user id", "Unauthorized")
+		return
+	}
+
+	userID, ok := userIDVal.(int)
+	if !ok {
+		utils.RespondError(ctx, http.StatusUnauthorized, nil, "GetUserStatus invalid user id", "Unauthorized")
+		return
+	}
+
+	isActive, err := userService.GetUserStatus(userID)
+	if err != nil {
+		if err == repositories.ErrUserNotFound {
+			utils.RespondError(ctx, http.StatusNotFound, err, "GetUserStatus user not found", "user not found")
+			return
+		}
+		utils.RespondError(ctx, http.StatusInternalServerError, err, "GetUserStatus service error", "Could not retrieve user status")
+		return
+	}
+
+	status := "deactivated"
+	if isActive {
+		status = "activated"
+	}
+
+	utils.RespondSuccess(ctx, http.StatusOK, utils.UserStatusResponse{Status: status})
+}

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -71,6 +71,20 @@ func GetUsernameByID(db *sql.DB, userID int) (string, error) {
 	return username, nil
 }
 
+// GetUserStatusByID returns whether the specified user is currently active.
+func GetUserStatusByID(db *sql.DB, userID int) (bool, error) {
+	var isActive bool
+	err := db.QueryRow("SELECT is_active FROM users WHERE id=$1", userID).Scan(&isActive)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, ErrUserNotFound
+		}
+		log.Printf("GetUserStatusByID query error for %d: %v", userID, err)
+		return false, err
+	}
+	return isActive, nil
+}
+
 // DeactivateUserTx sets a user's account as inactive within the supplied transaction.
 func DeactivateUserTx(tx *sql.Tx, userID int) error {
 	res, err := tx.Exec(`

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -67,6 +67,15 @@ func (s *UserService) GetUsernameByID(userID int) (string, error) {
 	return username, err
 }
 
+// GetUserStatus returns whether the provided user account is active.
+func (s *UserService) GetUserStatus(userID int) (bool, error) {
+	isActive, err := repositories.GetUserStatusByID(s.db, userID)
+	if err != nil {
+		log.Printf("GetUserStatus service error for %d: %v", userID, err)
+	}
+	return isActive, err
+}
+
 // DeactivateUser marks the account inactive and enqueues a lifecycle event for downstream cleanup.
 func (s *UserService) DeactivateUser(ctx context.Context, userID int, reason string) error {
 	tx, err := s.db.BeginTx(ctx, nil)

--- a/utils/responses.go
+++ b/utils/responses.go
@@ -55,3 +55,8 @@ type FriendRequestsResponse struct {
 type FriendRequestStatusResponse struct {
 	RequestStatus bool `json:"requestStatus"`
 }
+
+// UserStatusResponse represents a user's activation status.
+type UserStatusResponse struct {
+	Status string `json:"status"`
+}


### PR DESCRIPTION
## Summary
- add an authenticated `/user/status` endpoint that reports whether the account is activated
- expose user service and repository helpers to fetch the persisted activation flag
- add a reusable response payload for reporting a user's activation status

## Testing
- not run (go test ./... hangs while waiting for external dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e117389e6c832e801273f3556c1a40