### PR TITLE
Allow inactive users to access status endpoint

### DIFF
--- a/middlewares/authenticate.go
+++ b/middlewares/authenticate.go
@@ -62,6 +62,8 @@ func allowsInactiveAccess(c *gin.Context) bool {
 	switch c.FullPath() {
 	case "/user/reactivate":
 		return true
+	case "/user/status":
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary
- allow the authentication middleware to pass inactive users through when requesting /user/status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11b1748e8832e8e01c1a80144a385