### PR TITLE
Allow inactive accounts to access read-only endpoints

### DIFF
--- a/controllers/auth_test.go
+++ b/controllers/auth_test.go
@@ -187,6 +187,10 @@ func TestReactivateAllowsInactiveUser(t *testing.T) {
 		WithArgs(1).
 		WillReturnError(sql.ErrNoRows)
 
+	mock.ExpectQuery("SELECT username FROM users WHERE id=\\$1").
+		WithArgs(1).
+		WillReturnRows(sqlmock.NewRows([]string{"username"}).AddRow("john"))
+
 	mock.ExpectBegin()
 	mock.ExpectExec("\\s*UPDATE users\\s+SET is_active = true, deactivated_at = NULL\\s+WHERE id = \\$1 AND is_active = false").
 		WithArgs(1).

--- a/middlewares/authenticate_test.go
+++ b/middlewares/authenticate_test.go
@@ -1,0 +1,105 @@
+package middlewares_test
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/icpinto/dating-app/middlewares"
+	"github.com/icpinto/dating-app/services"
+	"github.com/icpinto/dating-app/utils"
+)
+
+func setupAuthRouter(db *sql.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	userService := services.NewUserService(db)
+	router.Use(middlewares.ServiceMiddleware(middlewares.Services{UserService: userService}))
+	return router
+}
+
+func TestAuthenticateAllowsInactiveUserForReadRoutes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error creating sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT username FROM users WHERE id=\\$1 AND is_active = true").
+		WithArgs(42).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT username FROM users WHERE id=\\$1").
+		WithArgs(42).
+		WillReturnRows(sqlmock.NewRows([]string{"username"}).AddRow("inactive_jane"))
+
+	router := setupAuthRouter(db)
+	router.GET("/user/matches/:user_id", middlewares.Authenticate, func(c *gin.Context) {
+		username := c.GetString("username")
+		c.JSON(http.StatusOK, gin.H{"username": username})
+	})
+
+	token, err := utils.GenerateToken(42)
+	if err != nil {
+		t.Fatalf("error generating token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/user/matches/42", nil)
+	req.Header.Set("Authorization", token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "inactive_jane") {
+		t.Fatalf("expected response to include username, got: %s", w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+func TestAuthenticateBlocksInactiveUserForWriteRoutes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error creating sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT username FROM users WHERE id=\\$1 AND is_active = true").
+		WithArgs(7).
+		WillReturnError(sql.ErrNoRows)
+
+	router := setupAuthRouter(db)
+	handlerCalled := false
+	router.POST("/user/sendRequest", middlewares.Authenticate, func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusOK)
+	})
+
+	token, err := utils.GenerateToken(7)
+	if err != nil {
+		t.Fatalf("error generating token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/user/sendRequest", nil)
+	req.Header.Set("Authorization", token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401 got %d: %s", w.Code, w.Body.String())
+	}
+	if handlerCalled {
+		t.Fatalf("handler should not be called for inactive write access")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -71,6 +71,20 @@ func GetUsernameByID(db *sql.DB, userID int) (string, error) {
 	return username, nil
 }
 
+// GetUsernameByIDAllowInactive returns the username even if the account is inactive.
+func GetUsernameByIDAllowInactive(db *sql.DB, userID int) (string, error) {
+	var username string
+	err := db.QueryRow("SELECT username FROM users WHERE id=$1", userID).Scan(&username)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrUserNotFound
+		}
+		log.Printf("GetUsernameByIDAllowInactive query error for %d: %v", userID, err)
+		return "", err
+	}
+	return username, nil
+}
+
 // GetUserStatusByID returns whether the specified user is currently active.
 func GetUserStatusByID(db *sql.DB, userID int) (bool, error) {
 	var isActive bool

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -67,6 +67,15 @@ func (s *UserService) GetUsernameByID(userID int) (string, error) {
 	return username, err
 }
 
+// GetUsernameByIDAllowInactive returns the username for the given user ID regardless of account status.
+func (s *UserService) GetUsernameByIDAllowInactive(userID int) (string, error) {
+	username, err := repositories.GetUsernameByIDAllowInactive(s.db, userID)
+	if err != nil {
+		log.Printf("GetUsernameByIDAllowInactive service error for %d: %v", userID, err)
+	}
+	return username, err
+}
+
 // GetUserStatus returns whether the provided user account is active.
 func (s *UserService) GetUserStatus(userID int) (bool, error) {
 	isActive, err := repositories.GetUserStatusByID(s.db, userID)


### PR DESCRIPTION
## Summary
- add repository and service helpers to resolve usernames for inactive accounts
- update authentication middleware to reuse the inactive lookup and broaden the read-only route whitelist
- add middleware coverage and update controller test to ensure inactive users can read but not write

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e15460665c832e835a6526a7d3b4e8