### PR TITLE
Restrict inactive users to request listing routes

### DIFF
--- a/middlewares/authenticate.go
+++ b/middlewares/authenticate.go
@@ -3,7 +3,6 @@ package middlewares
 import (
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt"
@@ -66,19 +65,8 @@ func allowsInactiveAccess(c *gin.Context) bool {
 	}
 
 	switch path {
-	case "/user/matches/:user_id",
-		"/user/profile",
-		"/user/profiles",
-		"/user/profile/:user_id",
-		"/user/core-preferences",
-		"/user/profile/enums",
-		"/user/requests",
-		"/user/sentRequests",
-		"/user/checkReqStatus/:reciver_id":
-		return true
-	}
-
-	if strings.HasPrefix(path, "/user/messages") {
+	case "/user/requests",
+		"/user/sentRequests":
 		return true
 	}
 


### PR DESCRIPTION
## Summary
- limit inactive account access to only the request and sent request GET endpoints while leaving status and reactivate available
- update authentication middleware tests to cover the new access rules

## Testing
- go test ./middlewares -run Authenticate

------
https://chatgpt.com/codex/tasks/task_e_68e18ae49fdc832e81272611f8376fd1